### PR TITLE
Allow invoking retries with less punctuation boilerplate.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ libraryDependencies ++= Seq(
   "me.lessis" %% "odelay-core" % "0.1.0",
   "org.scalatest" %% "scalatest" % "2.2.0" % "test")
 
+scalacOptions += "-feature"
+
 scalaVersion := crossScalaVersions.value.last
 
 licenses :=

--- a/src/test/scala/PolicySpec.scala
+++ b/src/test/scala/PolicySpec.scala
@@ -57,6 +57,17 @@ class PolicySpec extends FunSpec with BeforeAndAfterAll {
       Await.ready(future, Duration.Inf)
       assert(counter.get() === 4)
     }
+
+    it ("should accept a future in reduced syntax format") {
+      implicit val success = Success.always
+      val counter = new AtomicInteger()
+      val future = retry.Directly(1) {
+        counter.incrementAndGet()
+        Future.failed(new RuntimeException("always failing"))
+      }
+      Await.ready(future, Duration.Inf)
+      assert(counter.get() === 2)
+    }
   }
 
   describe("retry.Pause") {

--- a/src/test/scala/PolicySpec.scala
+++ b/src/test/scala/PolicySpec.scala
@@ -68,6 +68,20 @@ class PolicySpec extends FunSpec with BeforeAndAfterAll {
       Await.ready(future, Duration.Inf)
       assert(counter.get() === 2)
     }
+
+    it ("should retry futures passed by-name instead of caching results") {
+      implicit val success = Success.always
+      val counter = new AtomicInteger()
+      val future = retry.Directly(1) {
+        counter.getAndIncrement() match {
+          case 1 => Future.successful("yay!")
+          case _ => Future.failed(new RuntimeException("failed"))
+        }
+      }
+      val result: String = Await.result(future, Duration.Inf)
+      assert(counter.get() == 2)
+      assert(result == "yay!")
+    }
   }
 
   describe("retry.Pause") {


### PR DESCRIPTION
Given some function `attemptSomething()` that returns `Future[T]`, this allows clients to write:

```
retry.Directly(3) { attemptSomething() }
```

instead of

```
retry.Directly(3) { () => {
  attemptSomething()
}}
```

Includes one test, but compilation should get us the rest of the way there given the way the library is structured.