### PR TITLE
Add a new policy which supports exponential backoff + random jitter

### DIFF
--- a/src/main/scala/Defaults.scala
+++ b/src/main/scala/Defaults.scala
@@ -1,9 +1,13 @@
 package retry
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ ThreadLocalRandom, TimeUnit }
 
 object Defaults {
   val delay: FiniteDuration = Duration(500, TimeUnit.MILLISECONDS)
+  val cap: FiniteDuration = Duration(1, TimeUnit.MINUTES)
+  val jitter = Jitter.full()
+  val random: Jitter.RandomSource =
+    Jitter.randomSource(ThreadLocalRandom.current())
 }
 

--- a/src/main/scala/Jitter.scala
+++ b/src/main/scala/Jitter.scala
@@ -1,0 +1,155 @@
+package retry
+
+import java.util.Random
+
+import scala.concurrent.duration._
+import language.postfixOps
+
+trait Jitter {
+
+  def apply(
+    start: FiniteDuration,
+    last: FiniteDuration,
+    attempt: Int): FiniteDuration =
+      next(last, convert(start, last.unit), attempt)
+
+  protected def next(
+    start: FiniteDuration,
+    last: FiniteDuration,
+    attempt: Int): FiniteDuration
+
+  protected def convert(
+    dur: Duration,
+    unit: TimeUnit): FiniteDuration =
+      FiniteDuration(dur.toUnit(unit).toLong, unit)
+
+  protected def capped(
+    input: FiniteDuration,
+    cap: Duration)
+    (op: Long => Long): FiniteDuration = {
+      if (!cap.isFinite()) {
+        Duration(op(input.length), input.unit)
+      } else {
+        val ceil = convert(cap, input.unit)
+        val value = op(input.length)
+        if (value >= ceil.length) ceil
+        else Duration(value, input.unit)
+      }
+    }
+
+  protected def pow(
+    start: Long,
+    base: Long,
+    attempt: Long): Long = {
+      val temp = start * math.pow(base, attempt)
+      if (temp < 0.0 || temp > Long.MaxValue.toDouble) Long.MaxValue
+      else temp.toLong
+    }
+
+  protected def cappedPow(
+    start: FiniteDuration,
+    cap: Duration,
+    base: Long,
+    attempt: Long): FiniteDuration =
+      capped(start, cap) { len =>
+        pow(len, base, attempt) }
+}
+
+/** The algorithms here were inspired by this article:
+  * https://www.awsarchitectureblog.com/2015/03/backoff.html */
+object Jitter {
+
+  /** Given a lower and upper bound (inclusive) generate a random
+    * number within those bounds */
+  type RandomSource = (Long, Long) => Long
+
+  /** Create a RandomSource from an instance of java.util.Random
+    * Please be mindful of the call-by-name semantics */
+  def randomSource(random: => Random): RandomSource =
+    { (l, u) =>
+      val (_l, _u) = if (l < u) (l, u) else (u, l)
+      nextLong(random, (_u - _l) + 1) + _l
+    }
+
+  /** Simple exponential backoff + cap */
+  def none(
+    cap: Duration = Defaults.cap,
+    base: Int = 2): Jitter =
+      new Jitter {
+        protected def next(
+          start: FiniteDuration,
+          last: FiniteDuration,
+          attempt: Int): FiniteDuration =
+            cappedPow(start, cap, base, attempt)
+
+        override def toString = s"retry.Jitter.none($cap, $base)"
+      }
+
+  /** Normal exponential backoff + cap + random jitter */
+  def full(
+    cap: Duration = Defaults.cap,
+    random: RandomSource = Defaults.random,
+    base: Int = 2): Jitter =
+      new Jitter {
+        protected def next(
+          start: FiniteDuration,
+          last: FiniteDuration,
+          attempt: Int): FiniteDuration = {
+            val temp = cappedPow(start, cap, base, attempt)
+            Duration(random(0, temp.length), temp.unit)
+          }
+
+        override def toString = s"retry.Jitter.full($cap, $random, $base)"
+      }
+
+  /** Always keep some of the backoff and jitter by a smaller amount (prevents very short sleeps) */
+  def equal(
+    cap: Duration = Defaults.cap,
+    random: RandomSource = Defaults.random,
+    base: Int = 2): Jitter =
+      new Jitter {
+        protected def next(
+          start: FiniteDuration,
+          last: FiniteDuration,
+          attempt: Int): FiniteDuration = {
+            val temp = cappedPow(start, cap, base, attempt)
+            Duration(
+              temp.length / 2 + random(0, temp.length / 2),
+              temp.unit)
+          }
+
+        override def toString = s"retry.Jitter.equal($cap, $random, $base)"
+      }
+
+  /** similar to full, but we also increase the maximum jitter startd on the last random value. */
+  def decorrelated(
+    cap: Duration = Defaults.cap,
+    random: RandomSource = Defaults.random,
+    base: Int = 3): Jitter =
+      new Jitter {
+        protected def next(
+          start: FiniteDuration,
+          last: FiniteDuration,
+          attempt: Int): FiniteDuration =
+            capped(start, cap) { len =>
+              random(len, last.length * base) }
+
+        override def toString = s"retry.Jitter.decorrelated($cap, $random, $base)"
+      }
+
+  private def nextLong(
+    random: Random,
+    n: Long): Long = {
+      if (n <= 0L) throw new IllegalArgumentException()
+
+      // for small n use nextInt and cast
+      if (n <= Int.MaxValue) random.nextInt(n.toInt).toLong
+      else {
+        // for large n use nextInt for both high and low ints
+        val highLimit = (n >> 32).toInt
+        val high = random.nextInt(highLimit).toLong << 32
+        val low = random.nextInt().toLong & 0xffffffffL
+        high | low
+      }
+    }
+}

--- a/src/test/scala/JitterSpec.scala
+++ b/src/test/scala/JitterSpec.scala
@@ -1,0 +1,86 @@
+package retry
+
+import java.security.SecureRandom
+import java.util.Random
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.FunSpec
+import scala.concurrent.duration._
+import language.postfixOps
+
+class JitterSpec extends FunSpec {
+  val rng = new SecureRandom()
+  val rand = Jitter.randomSource(rng)
+  val cap = 2000 milliseconds
+
+  def testJitter(jitter: Jitter)(): Unit = {
+    val min = rand(1, 100) milliseconds
+    var sleep = rand(1, 1000) milliseconds
+
+    for (i <- 0 until 10000) {
+      val delay = sleep
+      sleep = jitter(delay, min, i+1)
+      assert(sleep.unit === TimeUnit.MILLISECONDS)
+      assert(sleep.length >= 0)
+      assert(sleep.length <= cap.length)
+    }
+  }
+
+  describe("retry.Defaults.random") {
+    it ("should return sane random values") {
+      for (i <- 0 until 1000) {
+        val result = rand(0, 10)
+        assert(result >= 0)
+        assert(result <= 10)
+      }
+    }
+
+    it ("should handle swapped bounds") {
+      for (i <- 0 until 1000) {
+        val result = rand(10, 0)
+        assert(result >= 0)
+        assert(result <= 10)
+      }
+    }
+
+    it ("should not cache random values") {
+      val counter = new AtomicInteger()
+      val rng = new Random() {
+        override def nextInt(): Int =
+          counter.addAndGet(1)
+        override def nextInt(n: Int): Int =
+          counter.addAndGet(1)
+      }
+
+      val rand = Jitter.randomSource(rng)
+      rand(0, 100)
+      rand(0, Int.MaxValue.toLong + 1L)
+      assert(counter.get() === 3)
+    }
+  }
+
+  describe("retry.Jitter.none") {
+    it ("should perform backoff correctly") {
+      testJitter(Jitter.none(cap))
+    }
+  }
+
+  describe("retry.Jitter.decorrelated") {
+    it ("should perform decorrelated jitter correctly") {
+      testJitter(Jitter.decorrelated(cap))
+    }
+  }
+
+  describe("retry.Jitter.full") {
+    it ("should perform full jitter correctly") {
+      testJitter(Jitter.full(cap))
+    }
+  }
+
+  describe("retry.Jitter.equal") {
+    it ("should perform equal jitter correctly") {
+      testJitter(Jitter.equal(cap))
+    }
+  }
+}

--- a/src/test/scala/PolicySpec.scala
+++ b/src/test/scala/PolicySpec.scala
@@ -1,5 +1,7 @@
 package retry
 
+import java.util.Random
+
 import org.scalatest.{ FunSpec, BeforeAndAfterAll }
 import odelay.Timer
 import scala.annotation.tailrec
@@ -11,6 +13,8 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 class PolicySpec extends FunSpec with BeforeAndAfterAll {
 
   val timer = implicitly[Timer]
+  val random = new Random()
+  val randomSource = Jitter.randomSource(random)
 
   override def afterAll() {
     timer.stop()
@@ -117,6 +121,100 @@ class PolicySpec extends FunSpec with BeforeAndAfterAll {
              s"took more time than expected: $took")
     }
   }
+
+  def testJitterBackoff(name: String, algoCreator: FiniteDuration => Jitter): Unit = {
+    describe(s"retry.JitterBackoff.$name") {
+
+      it ("should retry a future for a specified number of times") {
+        implicit val success = Success[Int](_ == 3)
+        implicit val algo = algoCreator(10.millis)
+        val tries = forwardCountingFutureStream().iterator
+        val policy = retry.JitterBackoff(3, 1.milli)
+        val result = Await.result(policy(tries.next), 1.second)
+        assert(success.predicate(result) === true)
+      }
+
+      it ("should fail when expected") {
+        implicit val algo = algoCreator(10.millis)
+        val success = implicitly[Success[Option[Int]]]
+        val tries = Future(None: Option[Int])
+        val policy = retry.JitterBackoff(3, 1.milli)
+        val result = Await.result(policy({ () => tries }),
+          1.second)
+        assert(success.predicate(result) === false)
+      }
+
+      it ("should deal with future failures") {
+        implicit val success = Success.always
+        implicit val algo = algoCreator(10.millis)
+        val policy = retry.JitterBackoff(3, 5.millis)
+        val counter = new AtomicInteger()
+        val future = policy { () =>
+          counter.incrementAndGet()
+          Future.failed(new RuntimeException("always failing"))
+        }
+        Await.ready(future, Duration.Inf)
+        assert(counter.get() === 4)
+      }
+
+      it ("should retry futures passed by-name instead of caching results") {
+        implicit val success = Success.always
+        implicit val algo = algoCreator(10.millis)
+        val counter = new AtomicInteger()
+        val policy = retry.JitterBackoff(1, 1.milli)
+        val future = policy {
+          counter.getAndIncrement() match {
+            case 1 => Future.successful("yay!")
+            case _ => Future.failed(new RuntimeException("failed"))
+          }
+        }
+        val result: String = Await.result(future, Duration.Inf)
+        assert(counter.get() == 2)
+        assert(result == "yay!")
+      }
+
+      it ("should pause with multiplier and jitter between retries") {
+        implicit val success = Success[Int](_ == 2)
+        implicit val algo = algoCreator(1000.millis)
+        val tries = forwardCountingFutureStream().iterator
+        val policy = retry.JitterBackoff(5, 50.millis)
+
+        val took = time {
+          val result = Await.result(policy(tries.next),
+            Duration.Inf)
+          assert(success.predicate(result) === true, "predicate failed")
+        }
+
+        assert(took >= 0.millis === true,
+          s"took less time than expected: $took")
+        assert(took <= 2000.millis === true,
+          s"took more time than expected: $took")
+      }
+
+      it ("should also work when invoked as forever") {
+        implicit val success = Success[Int](_ == 5)
+        implicit val algo = algoCreator(1000.millis)
+        val tries = forwardCountingFutureStream().iterator
+        val policy = retry.JitterBackoff.forever(50.millis)
+
+        val took = time {
+          val result = Await.result(policy(tries.next),
+            Duration.Inf)
+          assert(success.predicate(result) === true, "predicate failed")
+        }
+
+        assert(took >= 0.millis === true,
+          s"took less time than expected: $took")
+        assert(took <= 2000.millis === true,
+          s"took more time than expected: $took")
+      }
+    }
+  }
+
+  testJitterBackoff("none", t => Jitter.none(t))
+  testJitterBackoff("full", t => Jitter.full(t, random = randomSource))
+  testJitterBackoff("equal", t => Jitter.equal(t, random = randomSource))
+  testJitterBackoff("decorrelated", t => Jitter.decorrelated(t, random = randomSource))
 
   describe("retry.When") {
     it ("should retry conditionally when a condition is met") {


### PR DESCRIPTION
I found a great article about various approaches to adding jitter to exponential backoff:

https://www.awsarchitectureblog.com/2015/03/backoff.html

There's also an existing (python) proof of concept here:

https://github.com/awslabs/aws-arch-backoff-simulator/blob/master/src/backoff_simulator.py

Basically I took the article and coded it into a new retry.Policy. Let me know what you think.