### PR TITLE
JitterBackoff.forever should use the jitter value

### DIFF
--- a/src/main/scala/Policy.scala
+++ b/src/main/scala/Policy.scala
@@ -119,7 +119,7 @@ object JitterBackoff {
           (implicit success: Success[T],
            executor: ExecutionContext): Future[T] = {
             def run(attempt: Int, sleep: FiniteDuration): Future[T] = retry(promise, { () =>
-              Delay(delay) {
+              Delay(sleep) {
                 run(attempt + 1, jitter(delay, sleep, attempt))
               }.future.flatMap(identity)
             })


### PR DESCRIPTION
The `sleep` value calculated by the `jitter` is now being used in `Delay`.